### PR TITLE
Reload dotenv configuration for each worker run

### DIFF
--- a/amazon_invoices_worker.py
+++ b/amazon_invoices_worker.py
@@ -43,7 +43,7 @@ def run(
 
     logging.basicConfig(level=logging.INFO,
                         format="%(asctime)s %(levelname)s: %(message)s")
-    load_dotenv()
+    load_dotenv(dotenv_path=".env", override=True)
     USER, PW = os.getenv("AMZ_USER"), os.getenv("AMZ_PW")
     if not USER or not PW:
         log("Bitte AMZ_USER und AMZ_PW in der .env setzen")

--- a/checklist.md
+++ b/checklist.md
@@ -6,6 +6,7 @@
 - [x] Automate Amazon Business invoice retrieval with Selenium and optional headless mode.
 - [x] Parse downloaded PDFs to capture totals and payment references for database storage.
 - [x] Display downloaded invoices in a searchable, sortable table with running total.
+- [x] Reload worker environment configuration on every run so GUI updates take effect immediately.
 
 ## 🔄 In Progress / Planned
 - [ ] Provide packaged application binaries for Windows/macOS/Linux users.

--- a/concept.md
+++ b/concept.md
@@ -9,3 +9,4 @@ Core ideas:
 * Use a background worker to navigate the Amazon reports interface, discover invoice download links, and either download the PDFs directly through Selenium or reuse the authenticated session for high-speed `requests` downloads.
 * Parse downloaded PDFs to extract payment amounts and references, and persist the results in an SQLite database for quick lookup, filtering, and aggregation inside the GUI.
 * Provide an at-a-glance summary of downloaded invoices, including search and sum features, so users can reconcile finance records without manual portal work.
+* Ensure each retrieval run refreshes environment-driven credentials so updates in the GUI are respected immediately.

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ Amazon Invoices Downloader is a desktop application that automates the retrieval
 - Optional switch to use the active Selenium session cookies with `requests` for fast, reliable downloads.
 - Automatic PDF parsing to capture totals and payment references, saved to an SQLite database.
 - Qt-based table view that supports searching, sorting, and running totals over the downloaded invoices.
+- Worker reloads environment configuration on every invocation, so updated credentials or directories entered in the GUI are used immediately.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- reload the worker's dotenv configuration on every invocation so credentials and directories stay current
- document the refreshed environment behaviour across the concept, checklist, and README

## Testing
- python -m compileall amazon_invoices_worker.py amazon_invoices_gui_qt.py

------
https://chatgpt.com/codex/tasks/task_e_68d18b17d4b48321a416cfe77d8a4ab9