### PR TITLE
Align browser-mode downloads with metadata naming

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -16,3 +16,6 @@
 - [ ] Allow manual refresh of Amazon authentication cookies without a full relogin.
 - [ ] Document the database schema and provide migration tooling for future changes.
 - [ ] Add export options (CSV/Excel) for downloaded invoice metadata.
+
+## 🧪 Manual Regression Tests
+- [ ] Run a browser-mode download after a requests-mode download using the same invoice and confirm that both saved filenames include amount, currency, and payment reference metadata.

--- a/concept.md
+++ b/concept.md
@@ -7,6 +7,7 @@ Core ideas:
 * Offer a simple desktop front end where business users can enter their Amazon credentials, choose download destinations, and trigger automated invoice retrievals.
 * Protect sensitive credentials by encrypting them into an `.env.enc` file that only becomes a plaintext `.env` during a download session.
 * Use a background worker to navigate the Amazon reports interface, discover invoice download links, and either download the PDFs directly through Selenium or reuse the authenticated session for high-speed `requests` downloads.
+* Keep both download paths aligned by parsing every PDF for totals, currency, and payment references, renaming the saved files with that metadata, and recording the same enriched filename in the database.
 * Parse downloaded PDFs to extract payment amounts and references, and persist the results in an SQLite database for quick lookup, filtering, and aggregation inside the GUI.
 * Provide an at-a-glance summary of downloaded invoices, including search and sum features, so users can reconcile finance records without manual portal work.
 * Ensure each retrieval run refreshes environment-driven credentials so updates in the GUI are respected immediately.

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Amazon Invoices Downloader is a desktop application that automates the retrieval
 - Securely store Amazon credentials by encrypting them into an `.env.enc` file that is only decrypted during a download run.
 - Headless-friendly Selenium workflow that logs into the Amazon Business reports page and discovers newly available invoice PDFs.
 - Optional switch to use the active Selenium session cookies with `requests` for fast, reliable downloads.
-- Automatic PDF parsing to capture totals and payment references, saved to an SQLite database.
+- Automatic PDF parsing to capture totals and payment references, rename the PDFs with that metadata, and save everything to an SQLite database.
 - Qt-based table view that supports searching, sorting, and running totals over the downloaded invoices.
 - Worker reloads environment configuration on every invocation, so updated credentials or directories entered in the GUI are used immediately.
 
@@ -42,7 +42,7 @@ Python dependencies are listed in `requirements.txt` and include PySide6, Seleni
 2. Enter your Amazon Business username and password. Choose the download directory for PDFs and the SQLite database file used for metadata.
 3. Provide an encryption password. Credentials and settings are encrypted into `.env.enc` and only decrypted into a temporary `.env` file during downloads.
 4. (Optional) Enable **Per Browser herunterladen (--browser)** to force Selenium to perform the PDF downloads directly. Enable **Browserfenster anzeigen (--no-headless)** if you need to watch the automated browser.
-5. Click **Download starten**. The worker logs into Amazon Business, discovers new invoice links, downloads PDF files, parses totals and payment references, and stores metadata in the SQLite database.
+5. Click **Download starten**. The worker logs into Amazon Business, discovers new invoice links, downloads PDF files, parses totals and payment references, renames the PDFs with that metadata, and stores the enriched filenames and metadata in the SQLite database.
 6. Use **Datenbank neu laden** or the search field to refresh and filter the table. The **Summe** label shows the total of the currently displayed invoices.
 
 The GUI deletes the temporary `.env` file when the worker finishes. Existing `invoices.db` files will be migrated automatically if an outdated schema is detected; older data is preserved by renaming the legacy table.
@@ -69,3 +69,7 @@ The GUI deletes the temporary `.env` file when the worker finishes. Existing `in
 ## Testing
 
 There are currently no automated tests for the project. Contributions that add tests or continuous integration are welcome.
+
+### Manual regression checklist
+
+- Execute a run with **Per Browser herunterladen (--browser)** disabled to download via `requests`, note the metadata-enriched filename, then repeat the download with browser mode enabled and confirm the saved filename still includes the amount, currency, and payment reference.


### PR DESCRIPTION
## Summary
- wait for Selenium-driven downloads to finish, extract totals/currency/reference data, and rename PDFs in browser mode
- reuse the metadata-aware filename logging for the requests code path
- document the cross-mode naming behaviour and add a manual regression checklist entry

## Testing
- python -m compileall amazon_invoices_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68d1a5c88fb8832197d1f363a426450d