### PR TITLE
Improve localized amount parsing and add doctest

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -7,6 +7,7 @@
 - [x] Parse downloaded PDFs to capture totals and payment references for database storage.
 - [x] Display downloaded invoices in a searchable, sortable table with running total.
 - [x] Reload worker environment configuration on every run so GUI updates take effect immediately.
+- [x] Harden amount parsing with locale-aware normalization and doctest coverage for German and English formats.
 
 ## 🔄 In Progress / Planned
 - [ ] Provide packaged application binaries for Windows/macOS/Linux users.

--- a/concept.md
+++ b/concept.md
@@ -8,5 +8,6 @@ Core ideas:
 * Protect sensitive credentials by encrypting them into an `.env.enc` file that only becomes a plaintext `.env` during a download session.
 * Use a background worker to navigate the Amazon reports interface, discover invoice download links, and either download the PDFs directly through Selenium or reuse the authenticated session for high-speed `requests` downloads.
 * Parse downloaded PDFs to extract payment amounts and references, and persist the results in an SQLite database for quick lookup, filtering, and aggregation inside the GUI.
+* Normalize localized invoice totals so both German and English number formats are interpreted consistently during parsing.
 * Provide an at-a-glance summary of downloaded invoices, including search and sum features, so users can reconcile finance records without manual portal work.
 * Ensure each retrieval run refreshes environment-driven credentials so updates in the GUI are respected immediately.

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ Amazon Invoices Downloader is a desktop application that automates the retrieval
 - Headless-friendly Selenium workflow that logs into the Amazon Business reports page and discovers newly available invoice PDFs.
 - Optional switch to use the active Selenium session cookies with `requests` for fast, reliable downloads.
 - Automatic PDF parsing to capture totals and payment references, saved to an SQLite database.
+- Locale-aware normalization of invoice totals so German and English formatted amounts are interpreted consistently.
 - Qt-based table view that supports searching, sorting, and running totals over the downloaded invoices.
 - Worker reloads environment configuration on every invocation, so updated credentials or directories entered in the GUI are used immediately.
 
@@ -68,4 +69,8 @@ The GUI deletes the temporary `.env` file when the worker finishes. Existing `in
 
 ## Testing
 
-There are currently no automated tests for the project. Contributions that add tests or continuous integration are welcome.
+Basic doctest coverage exists for the amount normalisation helper:
+
+```bash
+python -m doctest amazon_invoices_worker.py
+```


### PR DESCRIPTION
## Summary
- add a reusable helper that keeps the correct decimal separator when normalizing localized amounts
- update the PDF parser to rely on the helper and handle German and English totals correctly
- document the new behaviour and doctest workflow in the concept, checklist, and README

## Testing
- python -m doctest amazon_invoices_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68d1a5c52da88321b08d678e4991e89c