### PR TITLE
Expand user paths for storage locations

### DIFF
--- a/amazon_invoices_gui_qt.py
+++ b/amazon_invoices_gui_qt.py
@@ -95,10 +95,11 @@ def load_encrypted_env(password):
     return result
 
 def load_invoices_from_db(db_path, search_term=None):
-    if not os.path.exists(db_path):
+    expanded_path = os.path.expanduser(db_path)
+    if not os.path.exists(expanded_path):
         return []
     try:
-        with sqlite3.connect(db_path) as conn:
+        with sqlite3.connect(expanded_path) as conn:
             cur = conn.cursor()
             query = (
                 "SELECT invoice_id, filename, amount, currency, payment_ref, downloaded_at "
@@ -118,10 +119,11 @@ def load_invoices_from_db(db_path, search_term=None):
         return []
 
 def sum_amounts_from_db(db_path, search_term=None):
-    if not os.path.exists(db_path):
+    expanded_path = os.path.expanduser(db_path)
+    if not os.path.exists(expanded_path):
         return 0.0
     try:
-        with sqlite3.connect(db_path) as conn:
+        with sqlite3.connect(expanded_path) as conn:
             cur = conn.cursor()
             query = "SELECT SUM(amount) FROM invoices"
             params = ()

--- a/amazon_invoices_worker.py
+++ b/amazon_invoices_worker.py
@@ -90,9 +90,11 @@ def run(
         log("Bitte AMZ_USER und AMZ_PW in der .env setzen")
         return
 
-    DOWNLOAD_DIR = Path(os.getenv("DOWNLOAD_DIR") or "invoices")
+    DOWNLOAD_DIR = Path(os.getenv("DOWNLOAD_DIR") or "invoices").expanduser()
     DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
-    DB_PATH = Path(os.getenv("DB_PATH") or "invoices.db")
+    DB_PATH = Path(os.getenv("DB_PATH") or "invoices.db").expanduser()
+    if not DB_PATH.parent.exists():
+        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     REPORT_URL = (
         "https://www.amazon.de/b2b/aba/reports"
         "?reportType=items_report_1"

--- a/checklist.md
+++ b/checklist.md
@@ -11,7 +11,7 @@
 - [x] Harden amount parsing with locale-aware normalization and doctest coverage for German and English formats.
 - [x] Strengthen encrypted configuration storage with salted PBKDF2 key derivation and surfaced save/load errors in the GUI.
 - [x] Replace brittle Selenium sleeps with DOM-aware waits and sanitize generated filenames for cross-platform safety.
-
+- [x] Resolve user-supplied paths like `~/Downloads` and create missing directories before the worker connects to SQLite or writes invoices.
 ## 🔄 In Progress / Planned
 - [ ] Provide packaged application binaries for Windows/macOS/Linux users.
 - [ ] Add automated tests or CI pipeline to catch regressions in GUI and worker logic.

--- a/concept.md
+++ b/concept.md
@@ -11,5 +11,6 @@ Core ideas:
 * Parse downloaded PDFs to extract payment amounts and references, and persist the results in an SQLite database for quick lookup, filtering, and aggregation inside the GUI.
 * Normalize localized invoice totals so both German and English number formats are interpreted consistently during parsing.
 * Provide an at-a-glance summary of downloaded invoices, including search and sum features, so users can reconcile finance records without manual portal work.
+* Expand user-provided paths (e.g. `~/Downloads`) and create required directories before worker runs so filesystem errors never block invoice retrievals.
 * Ensure each retrieval run refreshes environment-driven credentials so updates in the GUI are respected immediately while handling save/load errors gracefully within the UI.
 * Allow users to reload previously encrypted credentials and paths within the GUI so production runs never rely on mock inputs.

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ Python dependencies are listed in `requirements.txt` and include PySide6, Seleni
    ```bash
    python amazon_invoices_gui_qt.py
    ```
-2. Enter your Amazon Business username and password. Choose the download directory for PDFs and the SQLite database file used for metadata.
+2. Enter your Amazon Business username and password. Choose the download directory for PDFs and the SQLite database file used for metadata. Paths may include `~` to reference your home directory; the worker expands them and creates missing folders automatically before a run.
 3. Provide an encryption password. Credentials and settings are encrypted into `.env.enc` and only decrypted into a temporary `.env` file during downloads.
 4. If you already have an `.env.enc`, click **Konfiguration laden** to decrypt and prefill the stored credentials, directory, and database path. The entered password is reused for the next download run.
 5. (Optional) Enable **Per Browser herunterladen (--browser)** to force Selenium to perform the PDF downloads directly. Enable **Browserfenster anzeigen (--no-headless)** if you need to watch the automated browser.

--- a/roadmap.md
+++ b/roadmap.md
@@ -6,7 +6,7 @@
 - ✅ Stärker gehärtete Konfigurationsverschlüsselung (salted PBKDF2) und UI-Fehlerbehandlung beim Speichern/Laden.
 - ✅ Selenium-Navigation setzt auf DOM-Waits statt statische Sleeps und erzeugt betriebssichere Dateinamen.
 - 🔄 Dokumentation verfeinern (Nutzer-FAQ, Datenbankschema) und erste manuelle Regressionstests erfassen.
-
+- ✅ Nutzerpfade wie `~/Downloads` werden automatisch aufgelöst und fehlende Verzeichnisse angelegt, sodass Downloads und Datenbankzugriffe nicht mehr scheitern.
 ## Q3 2024 – Bedienkomfort & Zuverlässigkeit
 - [ ] Paketierte Builds für Windows/macOS/Linux bereitstellen.
 - [ ] Automatisierte Tests (GUI-Smoke-Tests, Worker-Integration) und CI-Pipeline aufsetzen.


### PR DESCRIPTION
## Summary
- expand tilde paths for download and database locations and ensure database directories exist before connecting
- normalise GUI database lookups by expanding user-supplied paths for listings and totals
- document the new behaviour in the concept, checklist, roadmap, and usage docs

## Testing
- python -m doctest amazon_invoices_worker.py

------
https://chatgpt.com/codex/tasks/task_e_68d59516d5a88321acb50e3c3b5ebbcc