### PR TITLE
Capture invoice dates and improve worker logging

### DIFF
--- a/amazon_invoices_gui_qt.py
+++ b/amazon_invoices_gui_qt.py
@@ -5,6 +5,7 @@ import hashlib
 import threading
 import sqlite3
 import logging
+from datetime import datetime
 import resources_rc
 from PySide6.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
@@ -108,16 +109,36 @@ def load_invoices_from_db(db_path, search_term=None):
     try:
         with sqlite3.connect(expanded_path) as conn:
             cur = conn.cursor()
-            query = (
-                "SELECT invoice_id, filename, amount, currency, payment_ref, downloaded_at "
-                "FROM invoices"
-            )
+            cur.execute("PRAGMA table_info(invoices)")
+            columns = {row[1] for row in cur.fetchall()}
+            has_invoice_date = "invoice_date" in columns
+            if has_invoice_date:
+                query = (
+                    "SELECT invoice_id, filename, amount, currency, payment_ref, "
+                    "COALESCE(invoice_date, downloaded_at) AS display_date "
+                    "FROM invoices"
+                )
+            else:
+                query = (
+                    "SELECT invoice_id, filename, amount, currency, payment_ref, downloaded_at "
+                    "FROM invoices"
+                )
             params = ()
             if search_term:
-                query += " WHERE invoice_id LIKE ? OR filename LIKE ? OR payment_ref LIKE ?"
                 like = f"%{search_term}%"
-                params = (like, like, like)
-            query += " ORDER BY downloaded_at DESC"
+                if has_invoice_date:
+                    query += (
+                        " WHERE invoice_id LIKE ? OR filename LIKE ? OR payment_ref LIKE ?"
+                        " OR invoice_date LIKE ?"
+                    )
+                    params = (like, like, like, like)
+                else:
+                    query += " WHERE invoice_id LIKE ? OR filename LIKE ? OR payment_ref LIKE ?"
+                    params = (like, like, like)
+            if has_invoice_date:
+                query += " ORDER BY COALESCE(invoice_date, downloaded_at) DESC, downloaded_at DESC"
+            else:
+                query += " ORDER BY downloaded_at DESC"
             cur.execute(query, params)
             rows = cur.fetchall()
             return rows
@@ -132,12 +153,22 @@ def sum_amounts_from_db(db_path, search_term=None):
     try:
         with sqlite3.connect(expanded_path) as conn:
             cur = conn.cursor()
+            cur.execute("PRAGMA table_info(invoices)")
+            columns = {row[1] for row in cur.fetchall()}
+            has_invoice_date = "invoice_date" in columns
             query = "SELECT SUM(amount) FROM invoices"
             params = ()
             if search_term:
-                query += " WHERE invoice_id LIKE ? OR filename LIKE ? OR payment_ref LIKE ?"
                 like = f"%{search_term}%"
-                params = (like, like, like)
+                if has_invoice_date:
+                    query += (
+                        " WHERE invoice_id LIKE ? OR filename LIKE ? OR payment_ref LIKE ?"
+                        " OR invoice_date LIKE ?"
+                    )
+                    params = (like, like, like, like)
+                else:
+                    query += " WHERE invoice_id LIKE ? OR filename LIKE ? OR payment_ref LIKE ?"
+                    params = (like, like, like)
             cur.execute(query, params)
             result = cur.fetchone()
             return result[0] if result and result[0] else 0.0
@@ -301,6 +332,25 @@ class MainWindow(QWidget):
                     amount = float(value)
                     item.setData(Qt.EditRole, amount)
                     item.setText(format_decimal_de(amount))
+                elif col_idx == 5:
+                    iso_text = str(value)
+                    dt_obj = None
+                    try:
+                        dt_obj = datetime.fromisoformat(iso_text)
+                    except ValueError:
+                        try:
+                            dt_obj = datetime.fromisoformat(iso_text.split("T")[0])
+                        except ValueError:
+                            dt_obj = None
+                    if dt_obj:
+                        item.setData(Qt.EditRole, dt_obj)
+                        item.setText(dt_obj.strftime("%d.%m.%Y"))
+                        if "T" in iso_text:
+                            item.setToolTip(
+                                f"Rechnungsdatum fehlte – Downloadzeit verwendet ({iso_text})."
+                            )
+                    else:
+                        item.setText(iso_text)
                 else:
                     item.setText(str(value))
                 self.table.setItem(row_idx, col_idx, item)

--- a/amazon_invoices_worker.py
+++ b/amazon_invoices_worker.py
@@ -115,6 +115,7 @@ def run(
         expected = {
             "invoice_id", "filename", "amount",
             "currency", "payment_ref", "downloaded_at",
+            "invoice_date",
         }
         return expected.issubset(cols)
 
@@ -165,7 +166,8 @@ def run(
                     amount          REAL,
                     currency        TEXT,
                     payment_ref     TEXT,
-                    downloaded_at   TEXT NOT NULL
+                    downloaded_at   TEXT NOT NULL,
+                    invoice_date    TEXT
                 )
                 """
             )
@@ -174,8 +176,19 @@ def run(
         else:
             log("Invoice-Tabelle entspricht bereits Schema-Version 1.")
 
+    def _migration_add_invoice_date_v2(conn: sqlite3.Connection) -> None:
+        cur = conn.execute("PRAGMA table_info(invoices)")
+        cols = {row[1] for row in cur.fetchall()}
+        if "invoice_date" not in cols:
+            conn.execute("ALTER TABLE invoices ADD COLUMN invoice_date TEXT")
+            conn.commit()
+            log("Spalte 'invoice_date' zur Invoice-Tabelle hinzugefügt (Schema-Version 2).")
+        else:
+            log("Spalte 'invoice_date' bereits vorhanden – keine Aktion erforderlich.")
+
     MIGRATIONS: list[tuple[int, Callable[[sqlite3.Connection], None]]] = [
         (1, _migration_create_invoices_v1),
+        (2, _migration_add_invoice_date_v2),
     ]
 
     def init_db() -> sqlite3.Connection:
@@ -193,9 +206,13 @@ def run(
 
     def is_already_downloaded(conn: sqlite3.Connection, invoice_id: str) -> bool:
         cur = conn.execute(
-            "SELECT 1 FROM invoices WHERE invoice_id = ? LIMIT 1", (invoice_id,)
+            "SELECT invoice_date IS NOT NULL FROM invoices WHERE invoice_id = ? LIMIT 1",
+            (invoice_id,),
         )
-        return cur.fetchone() is not None
+        row = cur.fetchone()
+        if row is None:
+            return False
+        return bool(row[0])
 
     def mark_as_downloaded(
         conn: sqlite3.Connection,
@@ -204,12 +221,21 @@ def run(
         amount: float | None,
         currency: str | None,
         payment_ref: str | None,
+        invoice_date: str | None,
     ):
+        now_iso = datetime.utcnow().isoformat(timespec="seconds")
         conn.execute(
             """
-            INSERT OR IGNORE INTO invoices
-            (invoice_id, filename, amount, currency, payment_ref, downloaded_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO invoices
+                (invoice_id, filename, amount, currency, payment_ref, downloaded_at, invoice_date)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(invoice_id) DO UPDATE SET
+                filename=excluded.filename,
+                amount=COALESCE(excluded.amount, invoices.amount),
+                currency=COALESCE(excluded.currency, invoices.currency),
+                payment_ref=COALESCE(excluded.payment_ref, invoices.payment_ref),
+                downloaded_at=excluded.downloaded_at,
+                invoice_date=COALESCE(excluded.invoice_date, invoices.invoice_date)
             """,
             (
                 invoice_id,
@@ -217,7 +243,8 @@ def run(
                 amount,
                 currency,
                 payment_ref,
-                datetime.utcnow().isoformat(timespec="seconds"),
+                now_iso,
+                invoice_date,
             ),
         )
         conn.commit()
@@ -286,6 +313,7 @@ def run(
         page = 1
         next_btn_locator = (By.CSS_SELECTOR, 'button[data-testid="next-button"]')
 
+        log("Suchzeitraum: Letzte 12 Wochen (PAST_12_WEEKS).")
         while True:
             log(f"Scanne Seite {page} …")
             links = extract_links_current_page()
@@ -327,6 +355,8 @@ def run(
                 log("Seitenwechsel nicht erkannt – breche ab.")
                 break
             page += 1
+        log(f"Seiten durchsucht: {page if page > 1 else 1}")
+        log(f"Neue Rechnungslinks gefunden: {len(all_new_links)}")
         return sorted(all_new_links)
 
     AMOUNT_PATTERNS = [
@@ -339,15 +369,78 @@ def run(
         re.compile(r"Payment\s+Reference\s+Number\s*[:#]?\s*(\S+)", re.I),
     ]
 
-    def parse_pdf_info(pdf_bytes: bytes) -> tuple[float | None, str | None, str | None]:
+    DATE_CANDIDATE_PATTERNS = [
+        re.compile(r"Rechnungsdatum\s*[:.]?\s*([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{4})", re.I),
+        re.compile(r"Rechnungsdatum\s*[:.]?\s*([0-9]{1,2}\.?\s+[A-Za-zÄÖÜäöüß]+\s+[0-9]{4})", re.I),
+        re.compile(r"Invoice\s+Date\s*[:.]?\s*([0-9]{1,2}[./-][0-9]{1,2}[./-][0-9]{2,4})", re.I),
+        re.compile(r"Invoice\s+Date\s*[:.]?\s*([0-9]{1,2}\s+[A-Za-z]+\s+[0-9]{4})", re.I),
+        re.compile(r"Ausgestellt\s+am\s*[:.]?\s*([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{4})", re.I),
+    ]
+
+    GERMAN_MONTHS = {
+        "januar": 1,
+        "februar": 2,
+        "märz": 3,
+        "maerz": 3,
+        "april": 4,
+        "mai": 5,
+        "juni": 6,
+        "juli": 7,
+        "august": 8,
+        "september": 9,
+        "oktober": 10,
+        "november": 11,
+        "dezember": 12,
+    }
+
+    def _parse_date_candidate(candidate: str) -> str | None:
+        text_candidate = candidate.strip().replace(",", "")
+        for fmt in ("%d.%m.%Y", "%d.%m.%y", "%Y-%m-%d", "%d/%m/%Y", "%m/%d/%Y"):
+            try:
+                dt = datetime.strptime(text_candidate, fmt)
+                return dt.date().isoformat()
+            except ValueError:
+                continue
+        try:
+            dt = datetime.strptime(text_candidate, "%d %B %Y")
+            return dt.date().isoformat()
+        except ValueError:
+            pass
+        m = re.match(r"(\d{1,2})(?:\.)?\s+([A-Za-zÄÖÜäöüß]+)\s+(\d{4})", text_candidate)
+        if m:
+            day = int(m.group(1))
+            month_name = m.group(2).strip().lower()
+            month_name = month_name.replace("ä", "ae").replace("ö", "oe").replace("ü", "ue").replace("ß", "ss")
+            month = GERMAN_MONTHS.get(month_name)
+            if month:
+                year = int(m.group(3))
+                try:
+                    return datetime(year, month, day).date().isoformat()
+                except ValueError:
+                    return None
+        return None
+
+    def extract_invoice_date(text: str) -> str | None:
+        for pattern in DATE_CANDIDATE_PATTERNS:
+            match = pattern.search(text)
+            if not match:
+                continue
+            candidate = match.group(1)
+            parsed = _parse_date_candidate(candidate)
+            if parsed:
+                return parsed
+        return None
+
+    def parse_pdf_info(pdf_bytes: bytes) -> tuple[float | None, str | None, str | None, str | None]:
         try:
             text = extract_text(io.BytesIO(pdf_bytes))
         except Exception as exc:
             log(f"PDF-Text konnte nicht extrahiert werden: {exc}")
-            return None, None, None
+            return None, None, None, None
         amount_val: float | None = None
         currency: str | None = None
         payment_ref: str | None = None
+        invoice_date: str | None = None
         for pat in AMOUNT_PATTERNS:
             if m := pat.search(text):
                 amount_str = m.group(1)
@@ -360,7 +453,50 @@ def run(
             if m := pat.search(text):
                 payment_ref = m.group(1)
                 break
-        return amount_val, currency, payment_ref
+        invoice_date = extract_invoice_date(text)
+        return amount_val, currency, payment_ref, invoice_date
+
+    def backfill_invoice_dates(conn: sqlite3.Connection) -> None:
+        cur = conn.execute(
+            "SELECT invoice_id, filename FROM invoices WHERE invoice_date IS NULL"
+        )
+        missing = cur.fetchall()
+        if not missing:
+            return
+        log(f"Fehlende Rechnungsdaten erkannt – versuche lokale PDFs auszuwerten ({len(missing)} offen).")
+        updates: list[tuple[str | None, float | None, str | None, str | None, str]] = []
+        for invoice_id, filename in missing:
+            pdf_path = DOWNLOAD_DIR / filename
+            if not pdf_path.exists():
+                log(f"PDF für {invoice_id} ({filename}) nicht gefunden – übersprungen.")
+                continue
+            try:
+                data = pdf_path.read_bytes()
+            except OSError as exc:
+                log(f"PDF {filename} konnte nicht gelesen werden ({exc}) – übersprungen.")
+                continue
+            if not data.startswith(b"%PDF"):
+                log(f"Datei {filename} ist kein gültiges PDF – übersprungen.")
+                continue
+            amount, currency, payment_ref, invoice_date = parse_pdf_info(data)
+            if invoice_date:
+                updates.append((invoice_date, amount, currency, payment_ref, invoice_id))
+        if updates:
+            conn.executemany(
+                """
+                UPDATE invoices
+                SET invoice_date = ?,
+                    amount = COALESCE(?, amount),
+                    currency = COALESCE(?, currency),
+                    payment_ref = COALESCE(?, payment_ref)
+                WHERE invoice_id = ?
+                """,
+                updates,
+            )
+            conn.commit()
+            log(f"Rechnungsdatum für {len(updates)} Rechnungen aus lokalen PDFs ergänzt.")
+        else:
+            log("Lokale PDFs enthielten keine zusätzlichen Rechnungsdaten.")
 
     INVALID_FILENAME_CHARS = set('<>:"/\\|?*')
 
@@ -428,20 +564,20 @@ def run(
                 if not data.getvalue().startswith(b"%PDF"):
                     log(f"Kein PDF-Header – übersprungen: {url}")
                     continue
-                amount, currency, payment_ref = parse_pdf_info(data.getvalue())
+                amount, currency, payment_ref, invoice_date = parse_pdf_info(data.getvalue())
                 final_name = build_final_filename(invoice_id, amount, currency, payment_ref)
                 dest_path = DOWNLOAD_DIR / final_name
                 if dest_path.exists():
                     log(f"{final_name} existiert bereits – wird übersprungen")
                     mark_as_downloaded(
-                        conn, invoice_id, final_name, amount, currency, payment_ref
+                        conn, invoice_id, final_name, amount, currency, payment_ref, invoice_date
                     )
                     continue
                 with open(dest_path, "wb") as f:
                     f.write(data.getvalue())
                 log(f"Gespeichert (Requests): {dest_path.name}")
                 mark_as_downloaded(
-                    conn, invoice_id, final_name, amount, currency, payment_ref
+                    conn, invoice_id, final_name, amount, currency, payment_ref, invoice_date
                 )
         finally:
             session.close()
@@ -497,7 +633,7 @@ def run(
                 except OSError:
                     pass
                 continue
-            amount, currency, payment_ref = parse_pdf_info(data)
+            amount, currency, payment_ref, invoice_date = parse_pdf_info(data)
             final_name = build_final_filename(invoice_id, amount, currency, payment_ref)
             dest_path = DOWNLOAD_DIR / final_name
             if dest_path.exists():
@@ -507,7 +643,7 @@ def run(
                         downloaded.unlink()
                 except OSError:
                     pass
-                mark_as_downloaded(conn, invoice_id, dest_path.name, amount, currency, payment_ref)
+                mark_as_downloaded(conn, invoice_id, dest_path.name, amount, currency, payment_ref, invoice_date)
                 continue
             try:
                 if downloaded != dest_path:
@@ -516,12 +652,13 @@ def run(
                 log(f"Zieldatei konnte nicht erstellt werden ({exc}) – übersprungen: {downloaded.name}")
                 continue
             log(f"Gespeichert (Browser): {dest_path.name}")
-            mark_as_downloaded(conn, invoice_id, dest_path.name, amount, currency, payment_ref)
+            mark_as_downloaded(conn, invoice_id, dest_path.name, amount, currency, payment_ref, invoice_date)
 
     # Main-Flow
     conn: sqlite3.Connection | None = None
     try:
         conn = init_db()
+        backfill_invoice_dates(conn)
         login_if_needed()
         log("Bericht geöffnet – sammle neue Links …")
         links = collect_links_all_pages(conn)

--- a/checklist.md
+++ b/checklist.md
@@ -14,6 +14,7 @@
 - [x] Resolve user-supplied paths like `~/Downloads` and create missing directories before the worker connects to SQLite or writes invoices.
 - [x] Close the GUI usability gaps by enabling table sorting, persisting the log history, localising totals, hardening amount parsing, and deduplicating invoice downloads.
 - [x] Document the database schema and add versioned migrations that preserve legacy invoice data.
+- [x] Parse and persist invoice dates, backfill existing entries, and surface the actual Rechnungsdatum in the GUI.
 ## 🔄 In Progress / Planned
 - [ ] Provide packaged application binaries for Windows/macOS/Linux users.
 - [ ] Add automated tests or CI pipeline to catch regressions in GUI and worker logic.

--- a/concept.md
+++ b/concept.md
@@ -9,6 +9,7 @@ Core ideas:
 * Use a background worker to navigate the Amazon reports interface, discover invoice download links, and either download the PDFs directly through Selenium or reuse the authenticated session for high-speed `requests` downloads.
 * Keep both download paths aligned by parsing every PDF for totals, currency, and payment references, renaming the saved files with sanitized metadata-rich filenames, and recording the same enriched filename in the database.
 * Parse downloaded PDFs to extract payment amounts and references, and persist the results in an SQLite database for quick lookup, filtering, and aggregation inside the GUI.
+* Erfasse zusätzlich das Rechnungsdatum aus den PDFs, speichere es zusammen mit dem Downloadzeitpunkt in SQLite und stelle sicher, dass die GUI das tatsächliche Rechnungsdatum hervorhebt.
 * Normalize localized invoice totals so both German and English number formats are interpreted consistently during parsing.
 * Provide an at-a-glance summary of downloaded invoices, including search and sum features, so users can reconcile finance records without manual portal work.
 * Offer finance teams a sortable, locale-aware invoice overview with persistent log history so download status and totals remain transparent.

--- a/readme.md
+++ b/readme.md
@@ -8,12 +8,13 @@ Amazon Invoices Downloader is a desktop application that automates the retrieval
 - Headless-friendly Selenium workflow that logs into the Amazon Business reports page and discovers newly available invoice PDFs.
 - Optional switch to use the active Selenium session cookies with `requests` for fast, reliable downloads.
 - Automatic PDF parsing to capture totals and payment references, saved to an SQLite database with filenames sanitised for all supported operating systems.
+- Extract and persist invoice dates from PDFs so the GUI shows the actual Rechnungsdatum while the database still tracks the download timestamp for auditing.
 - Smarter Selenium navigation that waits for invoice tables instead of relying on arbitrary sleep timers, increasing reliability without slowing downloads down.
 - Locale-aware normalization of invoice totals so German and English formatted amounts are interpreted consistently.
 - Qt-based table view that supports searching, sorting, and locale-aware running totals over the downloaded invoices.
 - Reload encrypted credentials and directory settings directly within the GUI for repeated runs.
 - Worker reloads environment configuration on every invocation, so updated credentials or directories entered in the GUI are used immediately.
-- Scrollable log history in the GUI that preserves worker progress messages across a full download run.
+- Scrollable log history in the GUI that preserves worker progress messages across a full download run, now including the selected search period and the number of portal pages scanned.
 
 ## Requirements
 
@@ -47,8 +48,8 @@ Python dependencies are listed in `requirements.txt` and include PySide6, Seleni
 3. Provide an encryption password. Credentials and settings are encrypted into `.env.enc` and only decrypted into a temporary `.env` file during downloads.
 4. If you already have an `.env.enc`, click **Konfiguration laden** to decrypt and prefill the stored credentials, directory, and database path. The entered password is reused for the next download run.
 5. (Optional) Enable **Per Browser herunterladen (--browser)** to force Selenium to perform the PDF downloads directly. Enable **Browserfenster anzeigen (--no-headless)** if you need to watch the automated browser.
-6. Click **Download starten**. The worker logs into Amazon Business, discovers new invoice links, downloads PDF files, parses totals and payment references, renames the PDFs with that metadata, and stores the enriched filenames and metadata in the SQLite database.
-7. Use **Datenbank neu laden** or the search field to refresh and filter the table. The **Summe** label shows the total of the currently displayed invoices.
+6. Click **Download starten**. The worker logs into Amazon Business, discovers new invoice links, downloads PDF files, parses totals, payment references, and invoice dates, renames the PDFs with that metadata, and stores the enriched filenames and metadata in the SQLite database.
+7. Use **Datenbank neu laden** or the search field to refresh and filter the table. The **Datum** column now reflects the invoice date (falling back to the download timestamp only when the PDF omits it), and the **Summe** label shows the total of the currently displayed invoices.
 
 The GUI deletes the temporary `.env` file when the worker finishes. Existing `invoices.db` files will be migrated automatically if an outdated schema is detected; older data is preserved by renaming the legacy table.
 
@@ -64,7 +65,7 @@ The worker initialises the SQLite database with a versioned schema so upgrades h
 
 | Table | Purpose | Columns |
 | --- | --- | --- |
-| `invoices` | Stores one row per downloaded invoice. | `invoice_id` (PK), `filename`, `amount`, `currency`, `payment_ref`, `downloaded_at` (UTC ISO-8601). |
+| `invoices` | Stores one row per downloaded invoice. | `invoice_id` (PK), `filename`, `amount`, `currency`, `payment_ref`, `downloaded_at` (UTC ISO-8601), `invoice_date` (ISO-8601 date). |
 | `schema_migrations` | Tracks applied schema versions. | `version` (PK), `applied_at` (UTC ISO-8601). |
 
 When the worker starts it creates the `schema_migrations` table (if required), checks the latest version, and applies outstanding migrations. Legacy `invoices` tables missing the modern columns are renamed to `invoices_legacy` before the current schema is created so historical data is preserved for manual review.

--- a/roadmap.md
+++ b/roadmap.md
@@ -8,6 +8,7 @@
 - ✅ Datenbankschema dokumentiert und leichtgewichtige Migrationserläuterung ergänzt (Nutzer-FAQ weiterhin offen).
 - ✅ GUI-Usability-Schulden abbauen: Tabellen-Sortierung aktivieren, Log-Historie anzeigen und Summen lokalisieren.
 - ✅ Nutzerpfade wie `~/Downloads` werden automatisch aufgelöst und fehlende Verzeichnisse angelegt, sodass Downloads und Datenbankzugriffe nicht mehr scheitern.
+- ✅ Rechnungsdatum automatisch aus PDFs extrahieren, lokal nachpflegen und im GUI-Datumsspaltenkopf anzeigen; Downloadzeitpunkt bleibt als separater Wert in SQLite erhalten.
 ## Q3 2024 – Bedienkomfort & Zuverlässigkeit
 - [ ] Paketierte Builds für Windows/macOS/Linux bereitstellen.
 - [ ] Automatisierte Tests (GUI-Smoke-Tests, Worker-Integration) und CI-Pipeline aufsetzen.


### PR DESCRIPTION
## Summary
- extract invoice dates from PDFs, persist them via a new schema migration, and backfill missing values from existing downloads
- surface the actual invoice date in the Qt table (with download timestamp fallback) and update worker logging with search range and page counts
- refresh project documentation to describe the new invoice-date workflow and logging details

## Testing
- python -m doctest amazon_invoices_worker.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69160e981dac8321b51dc9a96f802a43)