### PR TITLE
Add product name metadata to invoices

### DIFF
--- a/amazon_invoices_gui_qt.py
+++ b/amazon_invoices_gui_qt.py
@@ -112,34 +112,37 @@ def load_invoices_from_db(db_path, search_term=None):
             cur.execute("PRAGMA table_info(invoices)")
             columns = {row[1] for row in cur.fetchall()}
             has_invoice_date = "invoice_date" in columns
-            if has_invoice_date:
-                query = (
-                    "SELECT invoice_id, filename, amount, currency, payment_ref, "
-                    "COALESCE(invoice_date, downloaded_at) AS display_date "
-                    "FROM invoices"
-                )
-            else:
-                query = (
-                    "SELECT invoice_id, filename, amount, currency, payment_ref, downloaded_at "
-                    "FROM invoices"
-                )
-            params = ()
+            has_product_names = "product_names" in columns
+            select_parts = [
+                "invoice_id",
+                "filename",
+                "product_names" if has_product_names else "NULL AS product_names",
+                "amount",
+                "currency",
+                "payment_ref",
+                "COALESCE(invoice_date, downloaded_at) AS display_date"
+                if has_invoice_date
+                else "downloaded_at AS display_date",
+            ]
+            query = f"SELECT {', '.join(select_parts)} FROM invoices"
+            params: list[str] = []
             if search_term:
                 like = f"%{search_term}%"
+                conditions = [
+                    "invoice_id LIKE ?",
+                    "filename LIKE ?",
+                    "payment_ref LIKE ?",
+                ]
+                params.extend([like, like, like])
+                if has_product_names:
+                    conditions.append("product_names LIKE ?")
+                    params.append(like)
                 if has_invoice_date:
-                    query += (
-                        " WHERE invoice_id LIKE ? OR filename LIKE ? OR payment_ref LIKE ?"
-                        " OR invoice_date LIKE ?"
-                    )
-                    params = (like, like, like, like)
-                else:
-                    query += " WHERE invoice_id LIKE ? OR filename LIKE ? OR payment_ref LIKE ?"
-                    params = (like, like, like)
-            if has_invoice_date:
-                query += " ORDER BY COALESCE(invoice_date, downloaded_at) DESC, downloaded_at DESC"
-            else:
-                query += " ORDER BY downloaded_at DESC"
-            cur.execute(query, params)
+                    conditions.append("invoice_date LIKE ?")
+                    params.append(like)
+                query += " WHERE " + " OR ".join(conditions)
+            query += " ORDER BY display_date DESC, downloaded_at DESC"
+            cur.execute(query, tuple(params))
             rows = cur.fetchall()
             return rows
     except sqlite3.Error as exc:
@@ -156,20 +159,25 @@ def sum_amounts_from_db(db_path, search_term=None):
             cur.execute("PRAGMA table_info(invoices)")
             columns = {row[1] for row in cur.fetchall()}
             has_invoice_date = "invoice_date" in columns
+            has_product_names = "product_names" in columns
             query = "SELECT SUM(amount) FROM invoices"
-            params = ()
+            params: list[str] = []
             if search_term:
                 like = f"%{search_term}%"
+                conditions = [
+                    "invoice_id LIKE ?",
+                    "filename LIKE ?",
+                    "payment_ref LIKE ?",
+                ]
+                params.extend([like, like, like])
+                if has_product_names:
+                    conditions.append("product_names LIKE ?")
+                    params.append(like)
                 if has_invoice_date:
-                    query += (
-                        " WHERE invoice_id LIKE ? OR filename LIKE ? OR payment_ref LIKE ?"
-                        " OR invoice_date LIKE ?"
-                    )
-                    params = (like, like, like, like)
-                else:
-                    query += " WHERE invoice_id LIKE ? OR filename LIKE ? OR payment_ref LIKE ?"
-                    params = (like, like, like)
-            cur.execute(query, params)
+                    conditions.append("invoice_date LIKE ?")
+                    params.append(like)
+                query += " WHERE " + " OR ".join(conditions)
+            cur.execute(query, tuple(params))
             result = cur.fetchone()
             return result[0] if result and result[0] else 0.0
     except sqlite3.Error as exc:
@@ -242,8 +250,16 @@ class MainWindow(QWidget):
         layout.addLayout(actions)
 
         # Table
-        self.table = QTableWidget(0, 6)
-        self.table.setHorizontalHeaderLabels(["Rechnung", "Datei", "Betrag", "Währung", "Ref", "Datum"])
+        self.table = QTableWidget(0, 7)
+        self.table.setHorizontalHeaderLabels([
+            "Rechnung",
+            "Datei",
+            "Produkte",
+            "Betrag",
+            "Währung",
+            "Ref",
+            "Datum",
+        ])
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
@@ -328,11 +344,11 @@ class MainWindow(QWidget):
                 item = QTableWidgetItem()
                 if value is None:
                     item.setText("")
-                elif col_idx == 2:
+                elif col_idx == 3:
                     amount = float(value)
                     item.setData(Qt.EditRole, amount)
                     item.setText(format_decimal_de(amount))
-                elif col_idx == 5:
+                elif col_idx == 6:
                     iso_text = str(value)
                     dt_obj = None
                     try:
@@ -351,6 +367,11 @@ class MainWindow(QWidget):
                             )
                     else:
                         item.setText(iso_text)
+                elif col_idx == 2:
+                    text_value = str(value)
+                    item.setText(text_value)
+                    if text_value:
+                        item.setToolTip(text_value)
                 else:
                     item.setText(str(value))
                 self.table.setItem(row_idx, col_idx, item)

--- a/amazon_invoices_worker.py
+++ b/amazon_invoices_worker.py
@@ -186,9 +186,20 @@ def run(
         else:
             log("Spalte 'invoice_date' bereits vorhanden – keine Aktion erforderlich.")
 
+    def _migration_add_product_names_v3(conn: sqlite3.Connection) -> None:
+        cur = conn.execute("PRAGMA table_info(invoices)")
+        cols = {row[1] for row in cur.fetchall()}
+        if "product_names" not in cols:
+            conn.execute("ALTER TABLE invoices ADD COLUMN product_names TEXT")
+            conn.commit()
+            log("Spalte 'product_names' zur Invoice-Tabelle hinzugefügt (Schema-Version 3).")
+        else:
+            log("Spalte 'product_names' bereits vorhanden – keine Aktion erforderlich.")
+
     MIGRATIONS: list[tuple[int, Callable[[sqlite3.Connection], None]]] = [
         (1, _migration_create_invoices_v1),
         (2, _migration_add_invoice_date_v2),
+        (3, _migration_add_product_names_v3),
     ]
 
     def init_db() -> sqlite3.Connection:
@@ -206,7 +217,15 @@ def run(
 
     def is_already_downloaded(conn: sqlite3.Connection, invoice_id: str) -> bool:
         cur = conn.execute(
-            "SELECT invoice_date IS NOT NULL FROM invoices WHERE invoice_id = ? LIMIT 1",
+            """
+            SELECT CASE
+                     WHEN invoice_date IS NOT NULL AND product_names IS NOT NULL
+                     THEN 1 ELSE 0
+                   END
+            FROM invoices
+            WHERE invoice_id = ?
+            LIMIT 1
+            """,
             (invoice_id,),
         )
         row = cur.fetchone()
@@ -222,20 +241,31 @@ def run(
         currency: str | None,
         payment_ref: str | None,
         invoice_date: str | None,
+        product_names: str | None,
     ):
         now_iso = datetime.utcnow().isoformat(timespec="seconds")
         conn.execute(
             """
             INSERT INTO invoices
-                (invoice_id, filename, amount, currency, payment_ref, downloaded_at, invoice_date)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (
+                    invoice_id,
+                    filename,
+                    amount,
+                    currency,
+                    payment_ref,
+                    downloaded_at,
+                    invoice_date,
+                    product_names
+                )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(invoice_id) DO UPDATE SET
                 filename=excluded.filename,
                 amount=COALESCE(excluded.amount, invoices.amount),
                 currency=COALESCE(excluded.currency, invoices.currency),
                 payment_ref=COALESCE(excluded.payment_ref, invoices.payment_ref),
                 downloaded_at=excluded.downloaded_at,
-                invoice_date=COALESCE(excluded.invoice_date, invoices.invoice_date)
+                invoice_date=COALESCE(excluded.invoice_date, invoices.invoice_date),
+                product_names=COALESCE(excluded.product_names, invoices.product_names)
             """,
             (
                 invoice_id,
@@ -245,6 +275,7 @@ def run(
                 payment_ref,
                 now_iso,
                 invoice_date,
+                product_names,
             ),
         )
         conn.commit()
@@ -377,6 +408,26 @@ def run(
         re.compile(r"Ausgestellt\s+am\s*[:.]?\s*([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{4})", re.I),
     ]
 
+    PRODUCT_SECTION_HEADERS = [
+        re.compile(r"Beschreibung", re.I),
+        re.compile(r"Description", re.I),
+        re.compile(r"Bestellte\s+Artikel", re.I),
+        re.compile(r"Ordered\s+Items", re.I),
+    ]
+
+    PRODUCT_SECTION_STOPWORDS = [
+        re.compile(r"Zwischensumme", re.I),
+        re.compile(r"Subtotal", re.I),
+        re.compile(r"Summe", re.I),
+        re.compile(r"Gesamtbetrag", re.I),
+        re.compile(r"Total", re.I),
+        re.compile(r"Versand", re.I),
+        re.compile(r"Shipping", re.I),
+        re.compile(r"MwSt", re.I),
+        re.compile(r"VAT", re.I),
+        re.compile(r"Steuer", re.I),
+    ]
+
     GERMAN_MONTHS = {
         "januar": 1,
         "februar": 2,
@@ -431,16 +482,48 @@ def run(
                 return parsed
         return None
 
-    def parse_pdf_info(pdf_bytes: bytes) -> tuple[float | None, str | None, str | None, str | None]:
+    def extract_product_names(text: str) -> str | None:
+        lines = [re.sub(r"\s{2,}", " ", ln.strip()) for ln in text.splitlines()]
+        capture = False
+        collected: list[str] = []
+        for raw_line in lines:
+            if not raw_line:
+                continue
+            lower = raw_line.lower()
+            if not capture and any(pat.search(raw_line) for pat in PRODUCT_SECTION_HEADERS):
+                capture = True
+                continue
+            if capture and any(pat.search(raw_line) for pat in PRODUCT_SECTION_STOPWORDS):
+                break
+            if not capture:
+                continue
+            if re.search(r"\b(?:sku|asin|bestellnummer|order number)\b", lower):
+                continue
+            cleaned = re.sub(r"\s+[-\d.,]+\s*(?:eur|€)?$", "", raw_line, flags=re.I).strip()
+            cleaned = re.sub(r"^[\d\s]+x?\s+", "", cleaned)
+            if not cleaned:
+                continue
+            if not re.search(r"[A-Za-zÄÖÜäöüß]", cleaned):
+                continue
+            collected.append(cleaned)
+        if not collected:
+            return None
+        unique_order_preserving = list(dict.fromkeys(collected))
+        return "\n".join(unique_order_preserving) if unique_order_preserving else None
+
+    def parse_pdf_info(
+        pdf_bytes: bytes,
+    ) -> tuple[float | None, str | None, str | None, str | None, str | None]:
         try:
             text = extract_text(io.BytesIO(pdf_bytes))
         except Exception as exc:
             log(f"PDF-Text konnte nicht extrahiert werden: {exc}")
-            return None, None, None, None
+            return None, None, None, None, None
         amount_val: float | None = None
         currency: str | None = None
         payment_ref: str | None = None
         invoice_date: str | None = None
+        product_names: str | None = None
         for pat in AMOUNT_PATTERNS:
             if m := pat.search(text):
                 amount_str = m.group(1)
@@ -454,17 +537,21 @@ def run(
                 payment_ref = m.group(1)
                 break
         invoice_date = extract_invoice_date(text)
-        return amount_val, currency, payment_ref, invoice_date
+        product_names = extract_product_names(text)
+        return amount_val, currency, payment_ref, invoice_date, product_names
 
-    def backfill_invoice_dates(conn: sqlite3.Connection) -> None:
+    def backfill_invoice_metadata(conn: sqlite3.Connection) -> None:
         cur = conn.execute(
-            "SELECT invoice_id, filename FROM invoices WHERE invoice_date IS NULL"
+            "SELECT invoice_id, filename FROM invoices "
+            "WHERE invoice_date IS NULL OR product_names IS NULL"
         )
         missing = cur.fetchall()
         if not missing:
             return
         log(f"Fehlende Rechnungsdaten erkannt – versuche lokale PDFs auszuwerten ({len(missing)} offen).")
-        updates: list[tuple[str | None, float | None, str | None, str | None, str]] = []
+        updates: list[
+            tuple[str | None, str | None, float | None, str | None, str | None, str]
+        ] = []
         for invoice_id, filename in missing:
             pdf_path = DOWNLOAD_DIR / filename
             if not pdf_path.exists():
@@ -478,14 +565,22 @@ def run(
             if not data.startswith(b"%PDF"):
                 log(f"Datei {filename} ist kein gültiges PDF – übersprungen.")
                 continue
-            amount, currency, payment_ref, invoice_date = parse_pdf_info(data)
-            if invoice_date:
-                updates.append((invoice_date, amount, currency, payment_ref, invoice_id))
+            amount, currency, payment_ref, invoice_date, product_names = parse_pdf_info(data)
+            if invoice_date or product_names:
+                updates.append((
+                    invoice_date,
+                    product_names,
+                    amount,
+                    currency,
+                    payment_ref,
+                    invoice_id,
+                ))
         if updates:
             conn.executemany(
                 """
                 UPDATE invoices
-                SET invoice_date = ?,
+                SET invoice_date = COALESCE(?, invoice_date),
+                    product_names = COALESCE(?, product_names),
                     amount = COALESCE(?, amount),
                     currency = COALESCE(?, currency),
                     payment_ref = COALESCE(?, payment_ref)
@@ -494,7 +589,7 @@ def run(
                 updates,
             )
             conn.commit()
-            log(f"Rechnungsdatum für {len(updates)} Rechnungen aus lokalen PDFs ergänzt.")
+            log(f"Rechnungsdaten für {len(updates)} Rechnungen aus lokalen PDFs ergänzt.")
         else:
             log("Lokale PDFs enthielten keine zusätzlichen Rechnungsdaten.")
 
@@ -564,20 +659,36 @@ def run(
                 if not data.getvalue().startswith(b"%PDF"):
                     log(f"Kein PDF-Header – übersprungen: {url}")
                     continue
-                amount, currency, payment_ref, invoice_date = parse_pdf_info(data.getvalue())
+                amount, currency, payment_ref, invoice_date, product_names = parse_pdf_info(
+                    data.getvalue()
+                )
                 final_name = build_final_filename(invoice_id, amount, currency, payment_ref)
                 dest_path = DOWNLOAD_DIR / final_name
                 if dest_path.exists():
                     log(f"{final_name} existiert bereits – wird übersprungen")
                     mark_as_downloaded(
-                        conn, invoice_id, final_name, amount, currency, payment_ref, invoice_date
+                        conn,
+                        invoice_id,
+                        final_name,
+                        amount,
+                        currency,
+                        payment_ref,
+                        invoice_date,
+                        product_names,
                     )
                     continue
                 with open(dest_path, "wb") as f:
                     f.write(data.getvalue())
                 log(f"Gespeichert (Requests): {dest_path.name}")
                 mark_as_downloaded(
-                    conn, invoice_id, final_name, amount, currency, payment_ref, invoice_date
+                    conn,
+                    invoice_id,
+                    final_name,
+                    amount,
+                    currency,
+                    payment_ref,
+                    invoice_date,
+                    product_names,
                 )
         finally:
             session.close()
@@ -633,7 +744,7 @@ def run(
                 except OSError:
                     pass
                 continue
-            amount, currency, payment_ref, invoice_date = parse_pdf_info(data)
+            amount, currency, payment_ref, invoice_date, product_names = parse_pdf_info(data)
             final_name = build_final_filename(invoice_id, amount, currency, payment_ref)
             dest_path = DOWNLOAD_DIR / final_name
             if dest_path.exists():
@@ -643,7 +754,16 @@ def run(
                         downloaded.unlink()
                 except OSError:
                     pass
-                mark_as_downloaded(conn, invoice_id, dest_path.name, amount, currency, payment_ref, invoice_date)
+                mark_as_downloaded(
+                    conn,
+                    invoice_id,
+                    dest_path.name,
+                    amount,
+                    currency,
+                    payment_ref,
+                    invoice_date,
+                    product_names,
+                )
                 continue
             try:
                 if downloaded != dest_path:
@@ -652,13 +772,22 @@ def run(
                 log(f"Zieldatei konnte nicht erstellt werden ({exc}) – übersprungen: {downloaded.name}")
                 continue
             log(f"Gespeichert (Browser): {dest_path.name}")
-            mark_as_downloaded(conn, invoice_id, dest_path.name, amount, currency, payment_ref, invoice_date)
+            mark_as_downloaded(
+                conn,
+                invoice_id,
+                dest_path.name,
+                amount,
+                currency,
+                payment_ref,
+                invoice_date,
+                product_names,
+            )
 
     # Main-Flow
     conn: sqlite3.Connection | None = None
     try:
         conn = init_db()
-        backfill_invoice_dates(conn)
+        backfill_invoice_metadata(conn)
         login_if_needed()
         log("Bericht geöffnet – sammle neue Links …")
         links = collect_links_all_pages(conn)

--- a/checklist.md
+++ b/checklist.md
@@ -6,6 +6,7 @@
 - [x] Load existing encrypted credentials and paths directly in the Qt frontend.
 - [x] Automate Amazon Business invoice retrieval with Selenium and optional headless mode.
 - [x] Parse downloaded PDFs to capture totals and payment references for database storage.
+- [x] Persist extrahierte Produktnamen aus Rechnungs-PDFs, damit die Datenbank nach Artikelbezeichnungen durchsucht werden kann.
 - [x] Display downloaded invoices in a searchable table with running total.
 - [x] Reload worker environment configuration on every run so GUI updates take effect immediately.
 - [x] Harden amount parsing with locale-aware normalization and doctest coverage for German and English formats.

--- a/concept.md
+++ b/concept.md
@@ -8,7 +8,7 @@ Core ideas:
 * Protect sensitive credentials by encrypting them into an `.env.enc` file that only becomes a plaintext `.env` during a download session, using a salted PBKDF2-derived Fernet key to resist brute-force attacks.
 * Use a background worker to navigate the Amazon reports interface, discover invoice download links, and either download the PDFs directly through Selenium or reuse the authenticated session for high-speed `requests` downloads.
 * Keep both download paths aligned by parsing every PDF for totals, currency, and payment references, renaming the saved files with sanitized metadata-rich filenames, and recording the same enriched filename in the database.
-* Parse downloaded PDFs to extract payment amounts and references, and persist the results in an SQLite database for quick lookup, filtering, and aggregation inside the GUI.
+* Parse downloaded PDFs to extract payment amounts, references, and the underlying Produktbezeichnungen, and persist the results in an SQLite database for quick lookup, filtering, and aggregation inside the GUI.
 * Erfasse zusätzlich das Rechnungsdatum aus den PDFs, speichere es zusammen mit dem Downloadzeitpunkt in SQLite und stelle sicher, dass die GUI das tatsächliche Rechnungsdatum hervorhebt.
 * Normalize localized invoice totals so both German and English number formats are interpreted consistently during parsing.
 * Provide an at-a-glance summary of downloaded invoices, including search and sum features, so users can reconcile finance records without manual portal work.

--- a/readme.md
+++ b/readme.md
@@ -7,11 +7,11 @@ Amazon Invoices Downloader is a desktop application that automates the retrieval
 - Securely store Amazon credentials by encrypting them into an `.env.enc` file that is only decrypted during a download run, using a salted PBKDF2-derived Fernet key for brute-force resistance.
 - Headless-friendly Selenium workflow that logs into the Amazon Business reports page and discovers newly available invoice PDFs.
 - Optional switch to use the active Selenium session cookies with `requests` for fast, reliable downloads.
-- Automatic PDF parsing to capture totals and payment references, saved to an SQLite database with filenames sanitised for all supported operating systems.
+- Automatic PDF parsing to capture totals, payment references, and product names, saved to an SQLite database with filenames sanitised for all supported operating systems.
 - Extract and persist invoice dates from PDFs so the GUI shows the actual Rechnungsdatum while the database still tracks the download timestamp for auditing.
 - Smarter Selenium navigation that waits for invoice tables instead of relying on arbitrary sleep timers, increasing reliability without slowing downloads down.
 - Locale-aware normalization of invoice totals so German and English formatted amounts are interpreted consistently.
-- Qt-based table view that supports searching, sorting, and locale-aware running totals over the downloaded invoices.
+- Qt-based table view that supports searching (including product keywords), sorting, and locale-aware running totals over the downloaded invoices.
 - Reload encrypted credentials and directory settings directly within the GUI for repeated runs.
 - Worker reloads environment configuration on every invocation, so updated credentials or directories entered in the GUI are used immediately.
 - Scrollable log history in the GUI that preserves worker progress messages across a full download run, now including the selected search period and the number of portal pages scanned.
@@ -48,7 +48,7 @@ Python dependencies are listed in `requirements.txt` and include PySide6, Seleni
 3. Provide an encryption password. Credentials and settings are encrypted into `.env.enc` and only decrypted into a temporary `.env` file during downloads.
 4. If you already have an `.env.enc`, click **Konfiguration laden** to decrypt and prefill the stored credentials, directory, and database path. The entered password is reused for the next download run.
 5. (Optional) Enable **Per Browser herunterladen (--browser)** to force Selenium to perform the PDF downloads directly. Enable **Browserfenster anzeigen (--no-headless)** if you need to watch the automated browser.
-6. Click **Download starten**. The worker logs into Amazon Business, discovers new invoice links, downloads PDF files, parses totals, payment references, and invoice dates, renames the PDFs with that metadata, and stores the enriched filenames and metadata in the SQLite database.
+6. Click **Download starten**. The worker logs into Amazon Business, discovers new invoice links, downloads PDF files, parses totals, payment references, invoice dates, and product names, renames the PDFs with that metadata, and stores the enriched filenames and metadata in the SQLite database.
 7. Use **Datenbank neu laden** or the search field to refresh and filter the table. The **Datum** column now reflects the invoice date (falling back to the download timestamp only when the PDF omits it), and the **Summe** label shows the total of the currently displayed invoices.
 
 The GUI deletes the temporary `.env` file when the worker finishes. Existing `invoices.db` files will be migrated automatically if an outdated schema is detected; older data is preserved by renaming the legacy table.
@@ -56,7 +56,7 @@ The GUI deletes the temporary `.env` file when the worker finishes. Existing `in
 ## Data Storage
 
 - **PDF files** are saved to the configured download directory, defaulting to `invoices/`.
-- **Metadata** is stored in the configured SQLite database. The `invoices` table tracks invoice IDs, filenames, totals, currencies, payment references, and timestamps.
+- **Metadata** is stored in the configured SQLite database. The `invoices` table tracks invoice IDs, filenames, totals, currencies, payment references, timestamps, and the products contained in each invoice for keyword searches.
 - **Credentials** are stored encrypted in `.env.enc`. Never commit this file or the decrypted `.env` to version control.
 
 ### Database schema and migrations
@@ -65,7 +65,7 @@ The worker initialises the SQLite database with a versioned schema so upgrades h
 
 | Table | Purpose | Columns |
 | --- | --- | --- |
-| `invoices` | Stores one row per downloaded invoice. | `invoice_id` (PK), `filename`, `amount`, `currency`, `payment_ref`, `downloaded_at` (UTC ISO-8601), `invoice_date` (ISO-8601 date). |
+| `invoices` | Stores one row per downloaded invoice. | `invoice_id` (PK), `filename`, `amount`, `currency`, `payment_ref`, `downloaded_at` (UTC ISO-8601), `invoice_date` (ISO-8601 date), `product_names` (newline-separated text). |
 | `schema_migrations` | Tracks applied schema versions. | `version` (PK), `applied_at` (UTC ISO-8601). |
 
 When the worker starts it creates the `schema_migrations` table (if required), checks the latest version, and applies outstanding migrations. Legacy `invoices` tables missing the modern columns are renamed to `invoices_legacy` before the current schema is created so historical data is preserved for manual review.

--- a/roadmap.md
+++ b/roadmap.md
@@ -9,6 +9,7 @@
 - ✅ GUI-Usability-Schulden abbauen: Tabellen-Sortierung aktivieren, Log-Historie anzeigen und Summen lokalisieren.
 - ✅ Nutzerpfade wie `~/Downloads` werden automatisch aufgelöst und fehlende Verzeichnisse angelegt, sodass Downloads und Datenbankzugriffe nicht mehr scheitern.
 - ✅ Rechnungsdatum automatisch aus PDFs extrahieren, lokal nachpflegen und im GUI-Datumsspaltenkopf anzeigen; Downloadzeitpunkt bleibt als separater Wert in SQLite erhalten.
+- ✅ Produktnamen aus Rechnungs-PDFs extrahieren, in SQLite speichern und über die GUI-Suche auffindbar machen.
 ## Q3 2024 – Bedienkomfort & Zuverlässigkeit
 - [ ] Paketierte Builds für Windows/macOS/Linux bereitstellen.
 - [ ] Automatisierte Tests (GUI-Smoke-Tests, Worker-Integration) und CI-Pipeline aufsetzen.


### PR DESCRIPTION
## Summary
- add a schema migration that stores product names per invoice and backfills them from local PDFs
- extract product descriptions during downloads and persist them alongside totals and references
- extend the GUI search/table plus project docs to surface the stored product information

## Testing
- python -m py_compile amazon_invoices_worker.py amazon_invoices_gui_qt.py
- python -m doctest amazon_invoices_worker.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691612298c6c832195f8ea8ffcd4b083)